### PR TITLE
"c" now also does manchester decoding

### DIFF
--- a/dspectrum
+++ b/dspectrum
@@ -130,11 +130,27 @@ def threshold_safety_check raw, threshold
 
 end
 
+def manchester_decode demod
+  len=demod.length
+  i=0
+  output=''
+  while i < len-1 do
+    if (demod[i] == demod[i+1])
+      output+="E"
+    else
+      output+=demod[i+1]
+    end
+    i+=2
+  end
+  return output
+end
+
 def print_results demod
   hex = ''
   f_hex = '\x'
   hex << '%02x' % demod.to_i(2)
   f_hex << hex.scan(/.{2}|.+/).join('\x')
+  manch=manchester_decode(demod)
 
   puts
   puts
@@ -142,6 +158,7 @@ def print_results demod
   puts "[*] Hexcode: \t\t#{hex}".colorize(:green)
   puts "[*] Formatted Hexcode: \t#{f_hex}".colorize(:green)
   puts "[*] Ascii:  \t\t#{hex.gsub(/../) { |pair| pair.hex.chr }}".colorize(:green)
+  puts "[*] Manchester: \t#{manch}".colorize(:green)
   puts
   return hex
 end


### PR DESCRIPTION
My SDR instructor said manchester encoding is very widely used and he thinks lots of people would be grateful if dspectrum supported it.  So, if you like, this patch adds that support.

I don't know Ruby, so there's probably a cleaner way to do this.